### PR TITLE
SG-6302 better path handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+# PyCharm project settings
+.idea
+
+# Max OS X Desktop Services Store files
+.DS_Store

--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ import sgtk
 from sgtk.util.errors import PublishPathNotDefinedError, PublishPathNotSupported
 import sys
 import os
+import subprocess
 
 class LaunchFolder(sgtk.platform.Application):
     
@@ -72,18 +73,18 @@ class LaunchFolder(sgtk.platform.Application):
 
         # run the app
         if system.startswith("linux"):
-            cmd = 'xdg-open "%s"' % path
+            cmd_args = ['xdg-open', '"%s"' % path]
         elif system == "darwin":
-            cmd = 'open "%s"' % path
+            cmd_args = ['open', path]
         elif system == "win32":
-            cmd = 'cmd.exe /C start "Folder" "%s"' % path
+            cmd_args = ['cmd.exe', '/C', 'start', '"Folder"', '"%s"' % path]
         else:
             raise Exception("Platform '%s' is not supported." % system)
 
-        self.log_debug("Executing command '%s'" % cmd)
-        exit_code = os.system(cmd)
+        self.log_debug("Executing command '%s'" % cmd_args)
+        exit_code = subprocess.call(cmd_args)
         if exit_code != 0:
-            self.log_error("Failed to launch '%s'!" % cmd)
+            self.log_error("Failed to launch '%s'!" % cmd_args)
 
     def _launch_filemanager_for_file(self, path):
         """
@@ -106,20 +107,20 @@ class LaunchFolder(sgtk.platform.Application):
         if system.startswith("linux"):
             # Can't find a reliable way to open a file browser and select a file on linux,
             # so if we get passed a file path, only open up the folder.
-            cmd = 'xdg-open "%s"' % os.path.dirname(path)
+            cmd_args = ['xdg-open', os.path.dirname(path)]
         elif system == "darwin":
             # -R causes the open command to open a finder window and select the file within the parent directory.
-            cmd = 'open -R "%s"' % path
+            cmd_args = ['open', '-R', path]
         elif system == "win32":
             # /select makes windows select the file within the explorer window
-            cmd = 'explorer /select,"%s"' % path
+            cmd_args = ['explorer', '/select,', path]
         else:
             raise Exception("Platform '%s' is not supported." % system)
 
-        self.log_debug("Executing command '%s'" % cmd)
-        exit_code = os.system(cmd)
+        self.log_debug("Executing command '%s'" % cmd_args)
+        exit_code = subprocess.call(cmd_args)
         if exit_code != 0:
-            self.log_error("Failed to launch '%s'!" % cmd)
+            self.log_error("Failed to launch '%s'!" % cmd_args)
 
     def _get_published_file_path(self, entity_id):
         """

--- a/app.py
+++ b/app.py
@@ -43,7 +43,7 @@ class LaunchFolder(sgtk.platform.Application):
 
         # Find the publish so that we can get the path back.
         # Note there is a bug with the resolve_publish_path method requiring the `code` to be present, even though we
-        # don't really need it. If this bug (SG-8 is fixed in the future we can remove the need to gather the code.
+        # don't really need it. If this bug (SG-8561) is fixed in the future we can remove the need to gather the code.
         published_file = self.sgtk.shotgun.find_one("PublishedFile", [["id", "is", entity_id]], ["code", "path"])
         # Resolve the path for the local OS
         try:

--- a/app.py
+++ b/app.py
@@ -56,7 +56,8 @@ class LaunchFolder(sgtk.platform.Application):
         """
         This method will take a path to a folder and open it in the OS's default file manager.
         :param path: A folder path
-        :raises: Exception if the Platform is not supported, and ValueError if the path is not a valid directory.
+        :raises: Exception: if the Platform is not supported
+        :raises: ValueError: if the path is not a valid directory.
         """
         self.log_debug("Launching file system viewer for folder %s" % path)
 
@@ -88,7 +89,8 @@ class LaunchFolder(sgtk.platform.Application):
         This method will take a path to a file and open it in the OS's default file manager.
         This is only used for files, for folders use _launch_filemanager_for_folder.
         :param path: A file path
-        :raises: Exception if the Platform is not supported, and ValueError if the path is not a valid file.
+        :raises: Exception: if the Platform is not supported
+        :raises: ValueError: if the path is not a valid file.
         """
         self.log_debug("Launching file system viewer for file %s" % path)
 
@@ -168,29 +170,13 @@ class LaunchFolder(sgtk.platform.Application):
 
                 # Use the path cache to look up all paths linked to the task's entity
                 context = self.sgtk.context_from_entity(entity_type, eid)
-                context_paths = context.filesystem_locations
 
-                if context.step:
-                    # As steps are non project entities and not linked from the step to the other entities
-                    # you won't get step paths back from the context.filesystem_locations.
-                    # If we have a step in the context,
-                    # we should check to see if we can resolve the path more deeply using that.
-                    step_paths = self.sgtk.paths_from_entity("Step", context.step["id"])
+                # todo: Add support for step folders, when a step is present in the context, open the step folder
 
-                    for context_path in context_paths:
-                        # Loop over the context paths, and check to see if any of them can be extended with a step path.
-                        # We take the first match we come across.
-                        # If it can't fall back to the standard context path
-                        step_path = next((step_path for step_path in step_paths if step_path.startswith(context_path)),
-                                         None)
-                        if step_path:
-                            paths.append(step_path)
-                        else:
-                            paths.append(context_path)
-                else:
-                    # We don't have a PublishedFile path, or a step path, so we should just use the standard context paths
-                    # associated with this entity in the path cache.
-                    paths.extend(context_paths)
+                # We don't have a PublishedFile path, so we should just use the standard context paths
+                # associated with this entity in the path cache.
+                paths.extend(context.filesystem_locations)
+            self.log_info("paths: %s" % paths)
                             
         if len(paths) == 0:
             self.log_info("No location exists on disk yet for any of the selected entities. "

--- a/app.py
+++ b/app.py
@@ -12,11 +12,11 @@
 App that launches a folder browser from inside of Shotgun
 """
 
-import tank
+import sgtk
 import sys
 import os
 
-class LaunchFolder(tank.platform.Application):
+class LaunchFolder(sgtk.platform.Application):
     
     def init_app(self):
         entity_types = self.get_setting("entity_types")
@@ -33,11 +33,17 @@ class LaunchFolder(tank.platform.Application):
         self.engine.register_command("show_in_filesystem", self.show_in_filesystem, p)
             
     def launch(self, path):
-        self.log_debug("Launching file system viewer for folder %s" % path)        
-        
-        # get the setting        
+        """
+        This method will take a path to a folder and open it in the OS's default file manager.
+
+        :param path: A folder path
+        :return: None
+        """
+        self.log_debug("Launching file system viewer for folder %s" % path)
+
+        # get the setting
         system = sys.platform
-        
+
         # run the app
         if system == "linux2":
             cmd = 'xdg-open "%s"' % path
@@ -47,7 +53,36 @@ class LaunchFolder(tank.platform.Application):
             cmd = 'cmd.exe /C start "Folder" "%s"' % path
         else:
             raise Exception("Platform '%s' is not supported." % system)
-        
+
+        self.log_debug("Executing command '%s'" % cmd)
+        exit_code = os.system(cmd)
+        if exit_code != 0:
+            self.log_error("Failed to launch '%s'!" % cmd)
+
+    def launch_file_folder(self, path):
+        """
+        This method will take a path to a file and open it in the OS's default file manager.
+
+        :param path: A file path
+        :return: None
+        """
+        self.log_debug("Launching file system viewer for file %s" % path)
+
+        # get the setting
+        system = sys.platform
+
+        # build a command that will open and ideally select the file in the OS's default file manager
+        if system == "linux2":
+            # Can't find a reliable way to open a file browser and select a file on linux
+            # So if we get passed a file path, only open up the folder
+            cmd = 'xdg-open "%s"' % os.path.dirname(path)
+        elif system == "darwin":
+            cmd = 'open -R "%s"' % path
+        elif system == "win32":
+            cmd = 'explorer /select,"%s"' % path
+        else:
+            raise Exception("Platform '%s' is not supported." % system)
+
         self.log_debug("Executing command '%s'" % cmd)
         exit_code = os.system(cmd)
         if exit_code != 0:
@@ -60,11 +95,61 @@ class LaunchFolder(tank.platform.Application):
         with the given entity ids.
         """
         paths = []
-        
+
+        self.sgtk.synchronize_filesystem_structure()
+
         for eid in entity_ids:
+
+            if entity_type == "PublishedFile":
+                # Find the publish so that we can get the path back.
+                published_file = self.sgtk.shotgun.find_one("PublishedFile", [["id", "is", eid]], ['code', 'path'])
+                # Resolve the path for the local OS
+                try:
+                    local_path = sgtk.util.resolve_publish_path(self.sgtk, published_file)
+                except Exception as e:
+                    self.log_debug("Publish path couldn't be resolved falling back to context based path; reason: %s" % e)
+                    local_path = None
+
+                if local_path:
+                    if os.path.isdir(local_path):
+                        paths.append(local_path)
+                        continue
+                    elif os.path.isfile(local_path):
+                        paths.append(local_path)
+                        continue
+
+                    # possibly we have an image sequence and therefore its a symbolic path, instead check to see if
+                    # the parent folder of the path is valid and try opening that.
+                    # The issue with this logic is that possibly it was a directory that just didn't exist, as so
+                    # we would just be gathering the next directory up, ideally need a better way to handle sequences
+                    parent_dir = os.path.dirname(local_path)
+                    if parent_dir and os.path.isdir(parent_dir):
+                        paths.append(os.path.dirname(local_path))
+                        continue
+
             # Use the path cache to look up all paths linked to the task's entity
-            context = self.tank.context_from_entity(entity_type, eid)
-            paths.extend( context.filesystem_locations )
+            context = self.sgtk.context_from_entity(entity_type, eid)
+            context_paths = context.filesystem_locations
+
+            if context.step:
+                # As steps are non project entities and not linked from the step to the other entities you won't get step
+                # paths back from the context.filesystem_locations
+                # If we have a step in the context, we should check to see if we can resolve the path more deeply using that.
+                step_paths = self.sgtk.paths_from_entity("Step", context.step['id'])
+
+                for context_path in context_paths:
+                    # Loop over the context paths, and check to see if any of them can be extended with a step path.
+                    # If it can't fall back to the standard context path
+                    step_path = next((step_path for step_path in step_paths if step_path.startswith(context_path)),
+                                     None)
+                    if step_path:
+                        paths.append(step_path)
+                    else:
+                        paths.append(context_path)
+            else:
+                # We don't have a PublishedFile path, or a step path, so we should just use the standard context paths
+                # associated with this entity in the path cache.
+                paths.extend(context_paths)
                             
         if len(paths) == 0:
             self.log_info("No location exists on disk yet for any of the selected entities. "
@@ -72,5 +157,7 @@ class LaunchFolder(tank.platform.Application):
         else:
             # launch folder windows
             for x in paths:
-                self.launch(x)
-    
+                if os.path.isfile(str(x)):
+                    self.launch_file_folder(x)
+                else:
+                    self.launch(x)

--- a/app.py
+++ b/app.py
@@ -96,6 +96,8 @@ class LaunchFolder(sgtk.platform.Application):
         """
         paths = []
 
+        # As the this method relies on the path_cache to find the folders,
+        # we must check we are in sync before continuing
         self.sgtk.synchronize_filesystem_structure()
 
         for eid in entity_ids:
@@ -111,10 +113,8 @@ class LaunchFolder(sgtk.platform.Application):
                     local_path = None
 
                 if local_path:
-                    if os.path.isdir(local_path):
-                        paths.append(local_path)
-                        continue
-                    elif os.path.isfile(local_path):
+                    if (os.path.isdir(local_path) or os.path.isfile(local_path)):
+                        # If the path is pointing to a valid file or folder then its good to use as is.
                         paths.append(local_path)
                         continue
 
@@ -124,7 +124,7 @@ class LaunchFolder(sgtk.platform.Application):
                     # we would just be gathering the next directory up, ideally need a better way to handle sequences
                     parent_dir = os.path.dirname(local_path)
                     if parent_dir and os.path.isdir(parent_dir):
-                        paths.append(os.path.dirname(local_path))
+                        paths.append(parent_dir)
                         continue
 
             # Use the path cache to look up all paths linked to the task's entity
@@ -139,6 +139,7 @@ class LaunchFolder(sgtk.platform.Application):
 
                 for context_path in context_paths:
                     # Loop over the context paths, and check to see if any of them can be extended with a step path.
+                    # We take the first match we come across.
                     # If it can't fall back to the standard context path
                     step_path = next((step_path for step_path in step_paths if step_path.startswith(context_path)),
                                      None)

--- a/app.py
+++ b/app.py
@@ -99,7 +99,7 @@ class LaunchFolder(sgtk.platform.Application):
             self.log_info("No location exists on disk yet for any of the selected entities. "
                           "Please use shotgun to create folders and then try again!")
         else:
-            self.log_info("Paths to open: %s" % paths)
+            self.log_debug("Paths to open: %s" % paths)
             # launch folder windows
             for x in paths:
                 filesystem.open_file_browser(x)

--- a/app.py
+++ b/app.py
@@ -42,7 +42,7 @@ class LaunchFolder(sgtk.platform.Application):
         if os.path.isfile(path):
             self._launch_filemanager_for_file(path)
         elif os.path.isdir(path):
-            self._launch_filemanager_for_file(path)
+            self._launch_filemanager_for_folder(path)
         else:
             # possibly we have an image sequence and therefore its a symbolic path, instead check to see if
             # the parent folder of the path is valid and try opening that.
@@ -67,7 +67,7 @@ class LaunchFolder(sgtk.platform.Application):
         if os.path.isfile(path):
             raise ValueError(
                 "The path should be a folder not be a file path. "
-                "If you want to open a folder containing a file use _launch_filemanager_for_file path: %s" % path)
+                "If you want to open a folder containing a file use _launch_filemanager_for_file. Path: %s" % path)
 
         # get the setting
         system = sys.platform
@@ -100,7 +100,7 @@ class LaunchFolder(sgtk.platform.Application):
         if not os.path.isfile(path):
             raise ValueError(
                 "The path should be a file path not be a folder path. "
-                "If you want to open a folder use _launch_filemanager_for_folder, path: %s" % path)
+                "If you want to open a folder use _launch_filemanager_for_folder. Path: %s" % path)
 
         # get the setting
         system = sys.platform

--- a/app.py
+++ b/app.py
@@ -70,7 +70,7 @@ class LaunchFolder(sgtk.platform.Application):
         system = sys.platform
 
         # run the app
-        if system.startswith("linux2"):
+        if system.startswith("linux"):
             cmd = 'xdg-open "%s"' % path
         elif system == "darwin":
             cmd = 'open "%s"' % path
@@ -128,6 +128,8 @@ class LaunchFolder(sgtk.platform.Application):
         """
 
         # Find the publish so that we can get the path back.
+        # Note there is a bug with the resolve_publish_path method requiring the `code` to be present, even though we
+        # don't really need it. If this bug (SG-8 is fixed in the future we can remove the need to gather the code.
         published_file = self.sgtk.shotgun.find_one("PublishedFile", [["id", "is", entity_id]], ["code", "path"])
         # Resolve the path for the local OS
         try:
@@ -154,17 +156,17 @@ class LaunchFolder(sgtk.platform.Application):
 
         for eid in entity_ids:
 
-            file_path_found = False
+            pub_file_path = None
 
             if entity_type == "PublishedFile":
                 # If the entity type is a PublishedFile, we should try at first to extract the path of the publish
                 # and open the folder for that. If we can't we will fall back on the context driven path.
                 pub_file_path = self._get_published_file_path(eid)
-                if pub_file_path:
-                    paths.append(pub_file_path)
-                    file_path_found = True
 
-            if not file_path_found:
+            if pub_file_path:
+                paths.append(pub_file_path)
+
+            else:
                 # We've not found a path to a specific file for the entity, so we should try to resolve the path
                 # using the path cache instead.
 

--- a/app.py
+++ b/app.py
@@ -19,7 +19,6 @@ import os
 class LaunchFolder(sgtk.platform.Application):
     
     def init_app(self):
-        entity_types = self.get_setting("entity_types")
         deny_permissions = self.get_setting("deny_permissions")
         deny_platforms = self.get_setting("deny_platforms")
         
@@ -31,8 +30,31 @@ class LaunchFolder(sgtk.platform.Application):
         }
         
         self.engine.register_command("show_in_filesystem", self.show_in_filesystem, p)
-            
+
     def launch(self, path):
+        """
+        Given a path this method will choose the appropriate way to open that as a folder in the OS's default
+        file manager. Folders will be opened as is
+        :param path:
+        :return: None
+        """
+
+        if os.path.isfile(path):
+            self._launch_filemanager_for_file(path)
+        elif os.path.isdir(path):
+            self._launch_filemanager_for_file(path)
+        else:
+            # possibly we have an image sequence and therefore its a symbolic path, instead check to see if
+            # the parent folder of the path is valid and try opening that.
+            # todo: The issue with this logic is that possibly it was a directory that just didn't exist,
+            # so we would just be gathering the next directory up,
+            # ideally need a better way to handle sequences.
+            parent_dir = os.path.dirname(path)
+            if parent_dir and os.path.isdir(parent_dir):
+                self._launch_filemanager_for_folder(path)
+
+            
+    def _launch_filemanager_for_folder(self, path):
         """
         This method will take a path to a folder and open it in the OS's default file manager.
 
@@ -41,11 +63,17 @@ class LaunchFolder(sgtk.platform.Application):
         """
         self.log_debug("Launching file system viewer for folder %s" % path)
 
+        # Check that we don't have a file path.
+        if os.path.isfile(path):
+            raise ValueError(
+                "The path should be a folder not be a file path. "
+                "If you want to open a folder containing a file use _launch_filemanager_for_file path: %s" % path)
+
         # get the setting
         system = sys.platform
 
         # run the app
-        if system == "linux2":
+        if system.startswith("linux2"):
             cmd = 'xdg-open "%s"' % path
         elif system == "darwin":
             cmd = 'open "%s"' % path
@@ -59,22 +87,28 @@ class LaunchFolder(sgtk.platform.Application):
         if exit_code != 0:
             self.log_error("Failed to launch '%s'!" % cmd)
 
-    def launch_file_folder(self, path):
+    def _launch_filemanager_for_file(self, path):
         """
         This method will take a path to a file and open it in the OS's default file manager.
+        This is only used for files, for folders use _launch_filemanager_for_folder.
 
         :param path: A file path
         :return: None
         """
         self.log_debug("Launching file system viewer for file %s" % path)
 
+        if not os.path.isfile(path):
+            raise ValueError(
+                "The path should be a file path not be a folder path. "
+                "If you want to open a folder use _launch_filemanager_for_folder, path: %s" % path)
+
         # get the setting
         system = sys.platform
 
-        # build a command that will open and ideally select the file in the OS's default file manager
-        if system == "linux2":
-            # Can't find a reliable way to open a file browser and select a file on linux
-            # So if we get passed a file path, only open up the folder
+        # build a command that will open and ideally select the file in the OS's default file manager.
+        if system.startswith("linux"):
+            # Can't find a reliable way to open a file browser and select a file on linux,
+            # so if we get passed a file path, only open up the folder.
             cmd = 'xdg-open "%s"' % os.path.dirname(path)
         elif system == "darwin":
             cmd = 'open -R "%s"' % path
@@ -88,7 +122,27 @@ class LaunchFolder(sgtk.platform.Application):
         if exit_code != 0:
             self.log_error("Failed to launch '%s'!" % cmd)
 
-    
+    def _get_published_file_path(self, entity_id):
+        """
+        Will attempt to return back a resolved path for a PublishedFile entity
+        :param entity_id: int for the PublishedFile ID.
+        :return: str path or None depending on whether it successfully resolves the path.
+        """
+
+        # Find the publish so that we can get the path back.
+        published_file = self.sgtk.shotgun.find_one("PublishedFile", [["id", "is", entity_id]], ["code", "path"])
+        # Resolve the path for the local OS
+        try:
+            local_path = sgtk.util.resolve_publish_path(self.sgtk, published_file)
+        except Exception as e:
+            # It might fail to resolve the path to the publish if the published file is an uploaded file
+            # or URL, in which case we revert to the default context based method.
+            self.log_warning("Publish path couldn't be resolved "
+                             "falling back to context based path; reason: %s" % e)
+            local_path = None
+
+        return local_path
+
     def show_in_filesystem(self, entity_type, entity_ids):
         """
         Pop up a filesystem finder window for each folder associated
@@ -97,60 +151,50 @@ class LaunchFolder(sgtk.platform.Application):
         paths = []
 
         # As the this method relies on the path_cache to find the folders,
-        # we must check we are in sync before continuing
+        # we must check we are in sync before continuing.
         self.sgtk.synchronize_filesystem_structure()
 
         for eid in entity_ids:
 
+            file_path_found = False
+
             if entity_type == "PublishedFile":
-                # Find the publish so that we can get the path back.
-                published_file = self.sgtk.shotgun.find_one("PublishedFile", [["id", "is", eid]], ['code', 'path'])
-                # Resolve the path for the local OS
-                try:
-                    local_path = sgtk.util.resolve_publish_path(self.sgtk, published_file)
-                except Exception as e:
-                    self.log_debug("Publish path couldn't be resolved falling back to context based path; reason: %s" % e)
-                    local_path = None
+                # If the entity type is a PublishedFile, we should try at first to extract the path of the publish
+                # and open the folder for that. If we can't we will fall back on the context driven path.
+                pub_file_path = self._get_published_file_path(eid)
+                if pub_file_path:
+                    paths.append(pub_file_path)
+                    file_path_found = True
 
-                if local_path:
-                    if (os.path.isdir(local_path) or os.path.isfile(local_path)):
-                        # If the path is pointing to a valid file or folder then its good to use as is.
-                        paths.append(local_path)
-                        continue
+            if not file_path_found:
+                # We've not found path to a specific file for the entity, so we should try to resolve the path
+                # using the path cache instead.
 
-                    # possibly we have an image sequence and therefore its a symbolic path, instead check to see if
-                    # the parent folder of the path is valid and try opening that.
-                    # The issue with this logic is that possibly it was a directory that just didn't exist, as so
-                    # we would just be gathering the next directory up, ideally need a better way to handle sequences
-                    parent_dir = os.path.dirname(local_path)
-                    if parent_dir and os.path.isdir(parent_dir):
-                        paths.append(parent_dir)
-                        continue
+                # Use the path cache to look up all paths linked to the task's entity
+                context = self.sgtk.context_from_entity(entity_type, eid)
+                context_paths = context.filesystem_locations
 
-            # Use the path cache to look up all paths linked to the task's entity
-            context = self.sgtk.context_from_entity(entity_type, eid)
-            context_paths = context.filesystem_locations
+                if context.step:
+                    # As steps are non project entities and not linked from the step to the other entities
+                    # you won't get step paths back from the context.filesystem_locations.
+                    # If we have a step in the context,
+                    # we should check to see if we can resolve the path more deeply using that.
+                    step_paths = self.sgtk.paths_from_entity("Step", context.step["id"])
 
-            if context.step:
-                # As steps are non project entities and not linked from the step to the other entities you won't get step
-                # paths back from the context.filesystem_locations
-                # If we have a step in the context, we should check to see if we can resolve the path more deeply using that.
-                step_paths = self.sgtk.paths_from_entity("Step", context.step['id'])
-
-                for context_path in context_paths:
-                    # Loop over the context paths, and check to see if any of them can be extended with a step path.
-                    # We take the first match we come across.
-                    # If it can't fall back to the standard context path
-                    step_path = next((step_path for step_path in step_paths if step_path.startswith(context_path)),
-                                     None)
-                    if step_path:
-                        paths.append(step_path)
-                    else:
-                        paths.append(context_path)
-            else:
-                # We don't have a PublishedFile path, or a step path, so we should just use the standard context paths
-                # associated with this entity in the path cache.
-                paths.extend(context_paths)
+                    for context_path in context_paths:
+                        # Loop over the context paths, and check to see if any of them can be extended with a step path.
+                        # We take the first match we come across.
+                        # If it can't fall back to the standard context path
+                        step_path = next((step_path for step_path in step_paths if step_path.startswith(context_path)),
+                                         None)
+                        if step_path:
+                            paths.append(step_path)
+                        else:
+                            paths.append(context_path)
+                else:
+                    # We don't have a PublishedFile path, or a step path, so we should just use the standard context paths
+                    # associated with this entity in the path cache.
+                    paths.extend(context_paths)
                             
         if len(paths) == 0:
             self.log_info("No location exists on disk yet for any of the selected entities. "
@@ -158,7 +202,4 @@ class LaunchFolder(sgtk.platform.Application):
         else:
             # launch folder windows
             for x in paths:
-                if os.path.isfile(str(x)):
-                    self.launch_file_folder(x)
-                else:
-                    self.launch(x)
+                self.launch(x)

--- a/info.yml
+++ b/info.yml
@@ -42,7 +42,7 @@ description: "Jump from a Shotgun page to the file system."
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.13.0"
+requires_core_version: "v0.18.156"
 requires_engine_version: "v0.1.0"
 
 # the engines that this app can operate in:


### PR DESCRIPTION
This addresses tickets:
SG-6302
SG-4463
SG-6301

Updates:

- Now syncs path cache before trying to find context folders.
- Now will try to get the folder path from the `PublishedFile` entity `path` field, and highlight the file in the OS's prefered file manager. (Except Linux see below).
- Now tries to open a step folder if one is found and is deeper than the context folder. Before if you tried to "Show in filesystem" for a task, and the schema only had `Step` folders then it would only take you as far as the parent entity folder.
- Updated to use `sgtk` instead of `tank`.

There are a few things in this pull request, that I'm not sure about.

1. When trying to figure out if there is a deeper step folder, I'm having to gather context paths for the Step, and then match them against the entity's context folders. Whilst this works in my tests, I'm not sure if there are any scenarios that might break this. For example, I'm assuming that the step can only have one folder registered under the parent context folder, maybe I should account for multiple? Also, I'm not sure when a context can have multiple paths returned from `context.filesystem_locations`.

2. When getting the path for the PublishedFile entities, I'm checking if the path is a valid folder on disk, if not then I'm checking if its a valid file on disk, failing that I try to account for published files that contain symbolic paths such as sequences, where they use %04d. As it stands the code checks to see if the parent dir is valid and then just open that. This is flawed as potentially the received path is neither symbolic or valid, but the parent folder is, in which case I will just open the parent dir either way. I wonder if I should make some attempt perhaps through the use of regex to understand if its a sequence path?

3. If we are opening a folder containing a file path, it would be nice to select the file in the window. I have the method for doing this on Mac and Windows, however, I couldn't find a reliable way for achieving this on Linux. The inconsistency concerns me, although I would prefer to highlight the file when possible rather than not doing it for windows or mac just because I couldn't in Linux. Perhaps someone knows of a reliable way to do it in Linux? Maybe we should separate the logic into a hook to allow clients to adjust it to their needs?

4. Similar to above but as I'm gathering sequences as folder paths rather than file paths, I can't select the files. Is this a problem?

