### PR TITLE
SG-43662 Drop Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ exclude: "ui\/.*py$"
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v6.0.0
     hooks:
     # Ensures the code's syntax is correct.
     - id: check-ast
@@ -33,7 +33,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 26.5.1
     hooks:
     - id: black
       language_version: python3

--- a/info.yml
+++ b/info.yml
@@ -43,6 +43,7 @@ description: "Jump from a Flow Production Tracking page to the file system."
 # Required minimum versions for this item to run
 requires_shotgun_version:
 requires_core_version: "v0.18.156"
+minimum_python_version: "3.9"
 requires_engine_version: "v0.1.0"
 
 # the engines that this app can operate in:


### PR DESCRIPTION
Set `minimum_python_version` to `3.9` in the app manifest.